### PR TITLE
Update ProviderRole.hbm.xml

### DIFF
--- a/api/src/main/resources/ProviderRole.hbm.xml
+++ b/api/src/main/resources/ProviderRole.hbm.xml
@@ -40,7 +40,7 @@
         </set>
 
         <!-- link to supervisee roles -->
-        <set name="superviseeProviderRoles" table="providermanagement_provider_role_supervisee_provider_role">
+        <set name="superviseeProviderRoles" table="providermanagement_provider_role_supervisee_provider_role" inverse="false">
             <key column="provider_role_id" />
             <many-to-many column="supervisee_provider_role_id" class="org.openmrs.module.providermanagement.ProviderRole" />
         </set>


### PR DESCRIPTION
Changing the owner of the relationship type. This will automatically restrict the generation of the inverse constraint not required here for the many-to-many relationship. This will not require now to change the sqldiff create statement.