### PR TITLE
PROV-91 Added tests for methods in providerManagementUtils

### DIFF
--- a/api/src/test/java/org/openmrs/module/providermanagement/ProviderManagementUtilsTest.java
+++ b/api/src/test/java/org/openmrs/module/providermanagement/ProviderManagementUtilsTest.java
@@ -15,13 +15,29 @@
 package org.openmrs.module.providermanagement;
 
 import junit.framework.Assert;
+
+import org.junit.Before;
 import org.junit.Test;
+import org.openmrs.Person;
 import org.openmrs.Relationship;
 import org.openmrs.api.APIException;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.providermanagement.api.ProviderManagementService;
+import org.openmrs.module.providermanagement.exception.InvalidSupervisorException;
+import org.openmrs.module.providermanagement.exception.PersonIsNotProviderException;
+import org.openmrs.module.providermanagement.exception.ProviderAlreadyAssignedToSupervisorException;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+
+import static org.junit.Assert.assertNotNull;
 
 import java.util.Date;
 
-public class ProviderManagementUtilsTest {
+public class ProviderManagementUtilsTest extends BaseModuleContextSensitiveTest{
+	protected static final String XML_DATASET_PATH = "org/openmrs/module/providermanagement/include/";
+
+    protected static final String XML_DATASET = "providerManagement-dataset.xml";
+	
+	private ProviderManagementService providerManagementService;
 
     public static final Date DATE = ProviderManagementUtils.clearTimeComponent(new Date());
 
@@ -31,7 +47,87 @@ public class ProviderManagementUtilsTest {
 
     public static final Date FUTURE_DATE = ProviderManagementUtils.clearTimeComponent(new Date(DATE.getTime() + 31536000000L));
 
+    @Before
+    public void init() throws Exception {
+        // execute the provider management test dataset
+        executeDataSet(XML_DATASET_PATH + XML_DATASET);
 
+        // initialize the service
+        providerManagementService = Context.getService(ProviderManagementService.class);
+    }
+    
+    @Test
+    public void testClearTimeComponent(){
+    	Date date = new Date(2018, 11, 15);
+    	date.setHours(10);
+    	date.setMinutes(32);
+    	date.setSeconds(46);
+    	Date result = ProviderManagementUtils.clearTimeComponent(date);
+    	Assert.assertEquals(new Date(2018, 11, 15), result);
+    }
+    
+    @Test
+    public void testClearTimeComponentofNegativeDate(){
+    	Date date = new Date(1950, -1, 2);
+    	date.setHours(15);
+    	date.setMinutes(20);
+    	date.setSeconds(12);
+    	Date result = ProviderManagementUtils.clearTimeComponent(date);
+    	Assert.assertEquals(new Date(1950, -1, 2), result);
+    }
+    
+    @Test
+    public void testClearTimeComponentofNewDay(){
+    	Date date = new Date(2018, 7, 20);
+    	Date result = ProviderManagementUtils.clearTimeComponent(date);
+    	Assert.assertEquals(date, result);
+    }
+
+	@Test
+   	public void shouldSetupContext() {
+   		assertNotNull(Context.getService(ProviderManagementService.class));
+   	}
+    
+    @Test
+    public void shouldAssignProviderToSupervisorAndReturnListOfSupervisors() throws PersonIsNotProviderException, InvalidSupervisorException, ProviderAlreadyAssignedToSupervisorException {
+    	Provider superviseeProvider = new Provider();
+    	superviseeProvider.setIdentifier("1000X");
+    	Person supervisee = Context.getPersonService().getPerson(6);
+    	Person supervisor = Context.getPersonService().getPerson(2);
+    	superviseeProvider.setPerson(supervisee);
+    	providerManagementService.assignProviderToSupervisor(supervisee, supervisor);
+    	Assert.assertFalse(ProviderManagementUtils.getSupervisors(superviseeProvider).isEmpty());
+    	Assert.assertEquals(1, ProviderManagementUtils.getSupervisors(superviseeProvider).size());
+    }
+    
+    @Test
+    public void supervisorListShouldBeEmptyIfNoSupervisors() throws PersonIsNotProviderException {
+    	Provider provider = new Provider();
+    	Person person = Context.getPersonService().getPerson(6);
+    	provider.setPerson(person);
+    	Assert.assertTrue(ProviderManagementUtils.getSupervisors(provider).isEmpty());
+    }
+    
+    @Test
+    public void shouldAssignSuperviseeToProviderAndReturnListOfSupervisees() throws PersonIsNotProviderException, InvalidSupervisorException, ProviderAlreadyAssignedToSupervisorException {
+    	Provider supervisorProvider = new Provider();
+    	supervisorProvider.setIdentifier("1000X");
+    	Person supervisee = Context.getPersonService().getPerson(6);
+    	Person supervisor = Context.getPersonService().getPerson(2);
+    	supervisorProvider.setPerson(supervisor);
+    	providerManagementService.assignProviderToSupervisor(supervisee, supervisor);
+    	Assert.assertFalse(ProviderManagementUtils.getSupervisees(supervisorProvider).isEmpty());
+    	Assert.assertEquals(1, ProviderManagementUtils.getSupervisees(supervisorProvider).size());
+    }
+    
+    @Test
+    public void superviseeListShouldBeEmptyIfNoSupervisors() throws PersonIsNotProviderException {
+    	Provider provider = new Provider();
+    	Person person = Context.getPersonService().getPerson(6);
+    	provider.setPerson(person);
+    	Assert.assertTrue(ProviderManagementUtils.getSupervisees(provider).isEmpty());
+    }
+    
     @Test
     public void shouldReturnTrueForRelationshipWithStartDateInPastAndNoEndDate() {
         Relationship rel = new Relationship();
@@ -100,5 +196,4 @@ public class ProviderManagementUtilsTest {
         rel.setEndDate(PAST_DATE);
         ProviderManagementUtils.isRelationshipActive(rel);
     }
-
 }


### PR DESCRIPTION
Added test cases for getSupervisors:
Contribution for PROV-91. Added two test cases for getSupervisors;
Testing that the list returned is not empty after setting a
supervisor/supervisee relationship, Testing that the list returned is
empty on a provider with no supervisor, and testing that the list
returned is of proper length when a supervisor/supervisee relationship
exists.

Added test cases for clearTimeComponent:
Contribution for PROV-91. Added three test cases for clearTimeComponint;
Testing the date returned when passed a day that has already started (
(hour, min, second) != (0, 0, 0) ), testing the date returned when
passed a date with a negative value in the date, and testing the date
returned when passed a day that has just started ( (hour, min, second)
== (0, 0, 0) ).

Added test cases for getSupervisees:
Contribution for PROV-91. Added two test cases for getSupervisees;
Testing that the list returned is not empty after setting a
supervisor/supervisee relationship, Testing that the list returned is
empty on a provider with no supervisee, and testing that the list
returned is of proper length when a supervisor/supervisee relationship
exists.