### PR TITLE
RA-452: Sanitize provider list

### DIFF
--- a/omod/src/main/webapp/fragments/providerRoleList.gsp
+++ b/omod/src/main/webapp/fragments/providerRoleList.gsp
@@ -11,15 +11,15 @@
 
     <% providerRoles.each { %>
     <tr>
-        <td><a href="${ ui.pageLink("providermanagement", "editProviderRole", [providerRoleId: it.id]) }">${ (it.retired ? '<span class="retired">' + it.name + '</span>': it.name) }</a></td>
+        <td><a href="${ ui.pageLink("providermanagement", "editProviderRole", [providerRoleId: it.id]) }">${ (it.retired ? '<span class="retired">' + ui.encodeHtml(it.name) + '</span>': ui.encodeHtml(it.name)) }</a></td>
         <td>
-            ${ it.superviseeProviderRoles?.collect { (it.retired ? '<span class="retired">' + it.name + '</span>' : it.name) }.join(', ') }
+            ${ it.superviseeProviderRoles?.collect { (it.retired ? '<span class="retired">' + ui.encodeHtml(it.name) + '</span>' : ui.encodeHtml(it.name)) }.join(', ') }
         </td>
         <td>
-            ${ it.relationshipTypes?.collect { (it.retired ? '<span class="retired">' + it.aIsToB + '</span>' : it.aIsToB) }.join(', ') }
+            ${ it.relationshipTypes?.collect { (it.retired ? '<span class="retired">' + ui.encodeHtml(it.aIsToB) + '</span>' : ui.encodeHtml(it.aIsToB)) }.join(', ') }
         </td>
         <td>
-            ${ it.providerAttributeTypes?.collect { (it.retired ? '<span class="retired">' + it.name + '</span>' : it.name) }.join(', ') }
+            ${ it.providerAttributeTypes?.collect { (it.retired ? '<span class="retired">' + ui.encodeHtml(it.name) + '</span>' : ui.encodeHtml(it.name)) }.join(', ') }
         </td>
         <td>${ it.retired ? ui.message("general.yes") : ui.message("general.no") }</td>
          <td>


### PR DESCRIPTION
**Why**
Some of the gsp pages don't automatically encode html characters, making them vulnerable to xss. Admittedly this is a pretty unlikely attack vector, but there's really no drawback to html-encoding in this case.

**What Changed**
The provider-list gsp fragment now html-encodes provider names using OWASP encoders

**Decisions Made**
Decided to apply the patch in the view itself. Controller- or model-level html-encoding may be more comprehensive, but it also stands a greater chance of breaking preexisting functionality.