### PR TITLE
PROV-107 Add foreignKeyTableName to liquibase constraints

### DIFF
--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -58,7 +58,7 @@
 	<changeSet id="providermanagement-2b" author="pgutkowski">
 		<preConditions onFail="MARK_RAN" onError="WARN">
 			<not>
-				<foreignKeyConstraintExists
+				<foreignKeyConstraintExists foreignKeyTableName="provider"
 						foreignKeyName="provider_ibfk_1" />
 			</not>
 		</preConditions>


### PR DESCRIPTION
See https://openmrs.atlassian.net/browse/PROV-107

New versions of liquibase requires the foreignKeyTableName attribute to be set for any foreignKeyConstraintExists tags.